### PR TITLE
[MAN-953] Add Conan package for CryptoAuthLib

### DIFF
--- a/cryptoauthlib/conanfile.py
+++ b/cryptoauthlib/conanfile.py
@@ -1,0 +1,78 @@
+import os
+
+from conans import ConanFile, CMake
+
+
+class CryptoAuthLib(ConanFile):
+    name = 'cryptoauthlib'
+    version = '20190304'
+    url = 'https://github.com/wsbu/conan-packages'
+    homepage = 'https://github.com/MicrochipTech/cryptoauthlib'
+    description = 'Library for interacting with the Crypto Authentication secure elements.'
+    settings = 'os', 'compiler', 'build_type', 'arch'
+    license = 'MIT'
+    options = {
+        'shared': [True, False],
+        'hal_kit_hid': [True, False],
+        'hal_i2c': [True, False],
+        'hal_custom': [True, False],
+        'printf': [True, False],
+        'pkcs11': [True, False],
+        'mbedtls': [True, False]
+    }
+    default_options = {
+        'shared': True,
+        'hal_kit_hid': False,
+        'hal_i2c': False,
+        'hal_custom': False,
+        'printf': False,
+        'pkcs11': False,
+        'mbedtls': False
+    }
+
+    scm = {
+        'type': 'git',
+        'url': 'https://github.com/wsbu/cryptoauthlib.git',
+        'revision': version
+    }
+
+    def configure(self):
+        if self.settings.os == 'Linux' and self.options['hal_kit_id']:
+            raise Exception("Sorry - libudev isn't generally available in Conan yet so I can't build the library "
+                            "with this configuration.")
+
+    def build(self):
+        cmake = self.cmake
+        cmake.configure(source_folder=os.path.join(self.build_folder, 'lib'), build_folder=self.bin_dir)
+        cmake.build()
+
+    def package(self):
+        self.copy('*.so' if self.options.shared else '*.a', src=os.path.join(self.bin_dir), dst='lib')
+        self.copy('*.h', src=os.path.join(self.build_folder, 'lib'), dst='include')
+
+    def package_info(self):
+        self.cpp_info.libs = ['cryptoauth']
+        self.cpp_info.includedirs = [
+            'include',
+            os.path.join('include', 'hal'),
+            os.path.join('include', 'basic'),
+            os.path.join('include', 'crypto')
+        ]
+
+    @property
+    def cmake(self):
+        cmake = CMake(self)
+        cmake.definitions.update({
+            'ATCA_HAL_KIT_HID': 'ON' if self.options.hal_kit_hid else 'OFF',
+            'ATCA_HAL_I2C': 'ON' if self.options.hal_i2c else 'OFF',
+            'ATCA_HAL_CUSTOM': 'ON' if self.options.hal_custom else 'OFF',
+            'ATCA_PRINTF': 'ON' if self.options.printf else 'OFF',
+            'ATCA_PKCS11': 'ON' if self.options.pkcs11 else 'OFF',
+            'ATCA_MBEDTLS': 'ON' if self.options.mbedtls else 'OFF',
+            'ATCA_BUILD_SHARED_LIBS': 'ON' if self.options.shared else 'OFF'
+        })
+        return cmake
+
+    @property
+    def bin_dir(self):
+        return os.path.join(self.build_folder, 'build')

--- a/cryptoauthlib/test_package/CMakeLists.txt
+++ b/cryptoauthlib/test_package/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(CryptoAuthLibTest)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
+
+find_package(cryptoauthlib REQUIRED)
+
+add_compile_options(-fpermissive)
+
+add_executable("${PROJECT_NAME}" "${PROJECT_NAME}.cpp")
+target_link_libraries(${PROJECT_NAME} cryptoauthlib::cryptoauthlib)
+
+enable_testing()
+add_test(NAME ${PROJECT_NAME}
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} "$<TARGET_FILE:${PROJECT_NAME}>")

--- a/cryptoauthlib/test_package/CryptoAuthLibTest.cpp
+++ b/cryptoauthlib/test_package/CryptoAuthLibTest.cpp
@@ -1,0 +1,24 @@
+#include <string>
+#include <iostream>
+#include <atca_basic.h>
+
+using namespace std;
+
+static const string EXPECTED_VERSION = "20190304";
+
+int main () {
+    char actualVersion[32];
+    const auto status = atcab_version(actualVersion);
+
+    if (status) {
+        return status;
+    }
+
+    const string actualVersionStr = actualVersion;
+    if (EXPECTED_VERSION != actualVersionStr) {
+        cerr << "Expected " << EXPECTED_VERSION << " but got " << actualVersionStr << " instead." << endl;
+        return -1;
+    } else {
+        return 0;
+    }
+}

--- a/cryptoauthlib/test_package/conanfile.py
+++ b/cryptoauthlib/test_package/conanfile.py
@@ -1,0 +1,14 @@
+from conans import ConanFile, CMake
+
+
+class CryptoAuthLibTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        self.run('ctest --output-on-failure')


### PR DESCRIPTION
Time to try out the CryptoAuthLib library from Microchip on Linux, from the controller. Having a Conan package for the library should make that a bit faster.